### PR TITLE
Collapse xpath when parent and children are all using By.Xpath

### DIFF
--- a/src/main/java/com/lithium/mineraloil/selenium/elements/ElementActions.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/ElementActions.java
@@ -30,6 +30,8 @@ public interface ElementActions {
 
     Element getHoverElement();
 
+    Element getCollapsedParent();
+
     boolean isScrollIntoView();
 
     int getIndex();

--- a/src/main/java/com/lithium/mineraloil/selenium/elements/ElementActions.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/ElementActions.java
@@ -30,6 +30,10 @@ public interface ElementActions {
 
     By getBy();
 
+    By getCollapsedXpathBy();
+
+    Element getIframeElement();
+
     boolean isInDOM();
 
     boolean isDisplayed();

--- a/src/main/java/com/lithium/mineraloil/selenium/elements/ElementActions.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/ElementActions.java
@@ -28,6 +28,12 @@ public interface ElementActions {
 
     Element getParentElement();
 
+    Element getHoverElement();
+
+    boolean isScrollIntoView();
+
+    int getIndex();
+
     By getBy();
 
     By getCollapsedXpathBy();

--- a/src/main/java/com/lithium/mineraloil/selenium/elements/ElementImpl.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/ElementImpl.java
@@ -34,7 +34,6 @@ class ElementImpl<T extends Element> implements Element<T> {
 
     @Getter private By collapsedXpathBy;
     @Getter private Element collapsedParent;
-    @Getter private Element collapsedHoverElement;
 
 
     public ElementImpl(Element<T> referenceElement, By by) {
@@ -100,8 +99,7 @@ class ElementImpl<T extends Element> implements Element<T> {
             switchFocusFromIFrame();
         }
 
-        Element currentHoverElement = Optional.ofNullable(collapsedHoverElement).orElse(hoverElement);
-        if (currentHoverElement != null && currentHoverElement.isDisplayed()) currentHoverElement.hover();
+        if (hoverElement != null && hoverElement.isDisplayed()) hoverElement.hover();
 
         // cache element
         if (webElement != null) {
@@ -488,7 +486,6 @@ class ElementImpl<T extends Element> implements Element<T> {
     @Override
     public T withHover(Element hoverElement) {
         this.hoverElement = hoverElement;
-        collapseHoverXpath();
         return (T) referenceElement;
     }
 
@@ -542,32 +539,17 @@ class ElementImpl<T extends Element> implements Element<T> {
     }
 
     public By collapseXpath() {
-        if (parentElement != null && by instanceof ByXPath) {
+        if (parentElement != null && by instanceof ByXPath && parentElement.getIframeElement() == null && parentElement.getIndex() < 0) {
             By usedBy = Optional.ofNullable(parentElement.getCollapsedXpathBy()).orElse(parentElement.getBy());
-            if (parentElement.getIframeElement() == null && parentElement.getIndex() < 0 && usedBy instanceof ByXPath
-                    && !parentElement.isScrollIntoView()) {
+            if (usedBy instanceof ByXPath && !parentElement.isScrollIntoView()) {
                 String xpath = extractSelector(usedBy) + extractSelector(by);
-                collapsedHoverElement = parentElement.getHoverElement();
+                hoverElement = parentElement.getHoverElement();
                 collapsedParent = parentElement;
                 collapsedParent = collapsedParent.getCollapsedParent();
                 return By.xpath(xpath);
             }
         }
         return null;
-    }
-
-    // Assumes the child has a hover element
-    private void collapseHoverXpath() {
-        if (parentElement != null) {
-            // Reverts any collapsing that happened if the parentElement has a hoverElement
-            if (parentElement.getHoverElement() != null) {
-                collapsedXpathBy = null;
-                collapsedParent = null;
-                collapsedHoverElement = null;
-            } else {
-                collapsedHoverElement = parentElement.getHoverElement();
-            }
-        }
     }
 
 

--- a/src/main/java/com/lithium/mineraloil/selenium/elements/ElementImpl.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/ElementImpl.java
@@ -116,7 +116,7 @@ class ElementImpl<T extends Element> implements Element<T> {
         }
 
         By currentBy = Optional.ofNullable(collapsedXpathBy).orElse(by);
-        Element parent = Optional.ofNullable(collapsedParent).orElse(parentElement);
+        Element parent = collapsedXpathBy == null ? parentElement : collapsedParent;
         if (parent != null) {
             By parentBy = getByForParentElement(currentBy);
             if (index >= 0) {
@@ -548,7 +548,8 @@ class ElementImpl<T extends Element> implements Element<T> {
                     && !parentElement.isScrollIntoView()) {
                 String xpath = extractSelector(usedBy) + extractSelector(by);
                 collapsedHoverElement = parentElement.getHoverElement();
-                collapsedParent = parentElement.getParentElement();
+                collapsedParent = parentElement;
+                collapsedParent = collapsedParent.getCollapsedParent();
                 return By.xpath(xpath);
             }
         }
@@ -558,6 +559,7 @@ class ElementImpl<T extends Element> implements Element<T> {
     // Assumes the child has a hover element
     private void collapseHoverXpath() {
         if (parentElement != null) {
+            // Reverts any collapsing that happened if the parentElement has a hoverElement
             if (parentElement.getHoverElement() != null) {
                 collapsedXpathBy = null;
                 collapsedParent = null;

--- a/src/main/java/com/lithium/mineraloil/selenium/elements/ElementList.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/ElementList.java
@@ -2,15 +2,18 @@ package com.lithium.mineraloil.selenium.elements;
 
 import com.lithium.mineraloil.selenium.exceptions.ElementListException;
 import org.openqa.selenium.By;
+import org.openqa.selenium.By.ByXPath;
 import org.openqa.selenium.WebElement;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 public class ElementList<T extends Element> extends AbstractList<T> {
     protected final By by;
+    protected By combinedBy;
     private Class className;
     private Element<T> parentElement;
     private Element<T> iframeElement;
@@ -71,6 +74,7 @@ public class ElementList<T extends Element> extends AbstractList<T> {
 
     public ElementList<T> withParent(Element parentElement) {
         this.parentElement = parentElement;
+        this.combinedBy = collapseXpath();
         return this;
     }
 
@@ -108,5 +112,17 @@ public class ElementList<T extends Element> extends AbstractList<T> {
                                        .withHover(hoverElement);
         if (autoScrollIntoView) element.withAutoScrollIntoView();
         return element;
+    }
+
+    public By collapseXpath() {
+        if (parentElement != null && by instanceof ByXPath) {
+            By usedBy = Optional.ofNullable(parentElement.getCollapsedXpathBy()).orElse(parentElement.getBy());
+            if (parentElement.getIframeElement() == null && usedBy instanceof ByXPath) {
+                String xpath = ElementImpl.extractSelector(usedBy) + ElementImpl.extractSelector(by);
+                parentElement = parentElement.getParentElement();
+                return By.xpath(xpath);
+            }
+        }
+        return by;
     }
 }

--- a/src/main/java/com/lithium/mineraloil/selenium/elements/ElementList.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/ElementList.java
@@ -20,9 +20,7 @@ public class ElementList<T extends Element> extends AbstractList<T> {
     private Element<T> hoverElement;
     private boolean autoScrollIntoView;
 
-    private By collapsedXpathBy;
     private Element collapsedParent;
-    private Element collapsedHoverElement;
 
     public ElementList(By by, Class className) {
         this.by = by;
@@ -84,7 +82,6 @@ public class ElementList<T extends Element> extends AbstractList<T> {
 
     public ElementList<T> withHover(Element hoverElement) {
         this.hoverElement = hoverElement;
-        collapseHoverXpath();
         return this;
     }
 
@@ -120,31 +117,17 @@ public class ElementList<T extends Element> extends AbstractList<T> {
     }
 
     public By collapseXpath() {
-        if (parentElement != null && by instanceof ByXPath) {
+        if (parentElement != null && by instanceof ByXPath && parentElement.getIframeElement() == null && parentElement.getIndex() < 0 ) {
             By usedBy = Optional.ofNullable(parentElement.getCollapsedXpathBy()).orElse(parentElement.getBy());
-            if (parentElement.getIframeElement() == null && parentElement.getIndex() < 0 && usedBy instanceof ByXPath
+            if (usedBy instanceof ByXPath
                     && !parentElement.isScrollIntoView()) {
                 String xpath = ElementImpl.extractSelector(usedBy) + ElementImpl.extractSelector(by);
-                collapsedHoverElement = parentElement.getHoverElement();
+                hoverElement = parentElement.getHoverElement();
                 collapsedParent = parentElement;
                 collapsedParent = collapsedParent.getCollapsedParent();
                 return By.xpath(xpath);
             }
         }
         return null;
-    }
-
-    // Assumes the child has a hover element
-    private void collapseHoverXpath() {
-        if (parentElement != null) {
-            // Reverts any collapsing that happened if the parentElement has a hoverElement
-            if (parentElement.getHoverElement() != null) {
-                collapsedXpathBy = null;
-                collapsedParent = null;
-                collapsedHoverElement = null;
-            } else {
-                collapsedHoverElement = parentElement.getHoverElement();
-            }
-        }
     }
 }

--- a/src/test/java/com/lithium/mineraloil/selenium/elements/BaseElementTest.java
+++ b/src/test/java/com/lithium/mineraloil/selenium/elements/BaseElementTest.java
@@ -27,8 +27,8 @@ public class BaseElementTest extends BaseTest {
     @Test
     public void nestedElementLocate() {
         BaseElement grandparent = new BaseElement(By.xpath("//div[@id='nested_div']"));
-        BaseElement parent = grandparent.createBaseElement(By.xpath("div[@id='last_level']"));
-        BaseElement child = parent.createBaseElement(By.xpath("div[@class='duplicate_class']"));
+        BaseElement parent = grandparent.createBaseElement(By.xpath("//div[@id='last_level']"));
+        BaseElement child = parent.createBaseElement(By.xpath("//div[@class='duplicate_class']"));
         assertThat(child.getText()).isEqualTo("Nested Value With Shared Class");
     }
 
@@ -61,23 +61,6 @@ public class BaseElementTest extends BaseTest {
         assertThat(checkboxElement.isChecked()).isTrue();
         checkboxElement.uncheck();
         assertThat(checkboxElement.isChecked()).isFalse();
-    }
-
-    @Test
-    public void nestedElementCollapseXpath() {
-        BaseElement levelOne = new BaseElement(By.xpath("//div[@id='level_1']"));
-        BaseElement levelTwo = levelOne.createBaseElement(By.xpath("//div[@id='level_2']"));
-        BaseElement levelThree = levelTwo.createBaseElement(By.xpath("//div[@id='level_3']"));
-        assertThat(levelOne.getCollapsedXpathBy()).isNull();
-        assertThat(levelTwo.getCollapsedXpathBy().toString()).contains("//div[@id='level_1']",
-                                                                 "//div[@id='level_2']");
-        assertThat(levelTwo.getCollapsedXpathBy().toString()).doesNotContain("//div[@id='level_3']");
-        assertThat(levelThree.getCollapsedXpathBy().toString()).contains("//div[@id='level_1']",
-                                                                   "//div[@id='level_2']",
-                                                                   "//div[@id='level_3']");
-        assertThat(levelThree.getText()).contains("Level 3", "Welcome to the last level");
-        assertThat(levelTwo.getText()).contains("Level 2", "Level 3", "Welcome to the last level");
-        assertThat(levelOne.getText()).contains("Level 1", "Level 2", "Level 3", "Welcome to the last level");
     }
 
 

--- a/src/test/java/com/lithium/mineraloil/selenium/elements/BaseElementTest.java
+++ b/src/test/java/com/lithium/mineraloil/selenium/elements/BaseElementTest.java
@@ -63,4 +63,22 @@ public class BaseElementTest extends BaseTest {
         assertThat(checkboxElement.isChecked()).isFalse();
     }
 
+    @Test
+    public void nestedElementCollapseXpath() {
+        BaseElement levelOne = new BaseElement(By.xpath("//div[@id='level_1']"));
+        BaseElement levelTwo = levelOne.createBaseElement(By.xpath("//div[@id='level_2']"));
+        BaseElement levelThree = levelTwo.createBaseElement(By.xpath("//div[@id='level_3']"));
+        assertThat(levelOne.getCollapsedXpathBy()).isNull();
+        assertThat(levelTwo.getCollapsedXpathBy().toString()).contains("//div[@id='level_1']",
+                                                                 "//div[@id='level_2']");
+        assertThat(levelTwo.getCollapsedXpathBy().toString()).doesNotContain("//div[@id='level_3']");
+        assertThat(levelThree.getCollapsedXpathBy().toString()).contains("//div[@id='level_1']",
+                                                                   "//div[@id='level_2']",
+                                                                   "//div[@id='level_3']");
+        assertThat(levelThree.getText()).contains("Level 3", "Welcome to the last level");
+        assertThat(levelTwo.getText()).contains("Level 2", "Level 3", "Welcome to the last level");
+        assertThat(levelOne.getText()).contains("Level 1", "Level 2", "Level 3", "Welcome to the last level");
+    }
+
+
 }

--- a/src/test/java/com/lithium/mineraloil/selenium/elements/NestedXpathTest.java
+++ b/src/test/java/com/lithium/mineraloil/selenium/elements/NestedXpathTest.java
@@ -1,0 +1,120 @@
+package com.lithium.mineraloil.selenium.elements;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NestedXpathTest {
+
+    @Test
+    public void nestedElementCollapseXpath() {
+        BaseElement levelOne = new BaseElement(By.xpath("//div[@id='level_1']"));
+        BaseElement levelTwo = levelOne.createBaseElement(By.xpath("//div[@id='level_2']"));
+        BaseElement levelThree = levelTwo.createBaseElement(By.xpath("//div[@id='level_3']"));
+        BaseElement levelFour = levelThree.createBaseElement(By.xpath("//div[@id='level_4']"));
+        assertThat(levelOne.getCollapsedXpathBy()).isNull();
+        assertThat(levelTwo.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='level_1']//div[@id='level_2']"));
+        assertThat(levelThree.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='level_1']//div[@id='level_2']//div[@id='level_3']"));
+        assertThat(levelFour.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='level_1']//div[@id='level_2']//div[@id='level_3']//div[@id='level_4']"));
+//        assertThat(levelThree.getText()).contains("Level 3", "Welcome to the last level");
+//        assertThat(levelTwo.getText()).contains("Level 2", "Level 3", "Welcome to the last level");
+//        assertThat(levelOne.getText()).contains("Level 1", "Level 2", "Level 3", "Welcome to the last level");
+    }
+
+    @Ignore
+    @Test
+    public void nestedElementList() {
+        ElementList<BaseElement> list = new ElementList<>(By.xpath("//li[@class='nested_item']"), BaseElement.class);
+        assertThat(list).hasSize(3);
+        assertThat(list.get(0).getText()).isEqualTo("Item 1");
+        assertThat(list.get(1).getText()).isEqualTo("Item 2");
+        assertThat(list.get(2).getText()).isEqualTo("Item 3");
+    }
+
+    @Ignore
+    @Test
+    public void nestedElementListWithNestedElement() {
+        ElementList<BaseElement> list = new ElementList<>(By.xpath("//li[@class='nested_item']"), BaseElement.class);
+        BaseElement item1 = list.get(0).createBaseElement(By.xpath("//div[@class='nested_text']"));
+        BaseElement item2 = list.get(1).createBaseElement(By.xpath("//div[@class='nested_text']"));
+        BaseElement item3 = list.get(2).createBaseElement(By.xpath("//div[@class='nested_text']"));
+        assertThat(item1.getText()).isEqualTo("Item 1");
+        assertThat(item2.getText()).isEqualTo("Item 2");
+        assertThat(item3.getText()).isEqualTo("Item 3");
+    }
+
+    @Test
+    public void nestedElementsWithHover() {
+        BaseElement hoverElement = new BaseElement(By.xpath("//div[@id='hoverElement']"));
+        BaseElement elementWithHover = new BaseElement(By.xpath("//div[@id='elementWithHover']")).withHover(hoverElement);
+        BaseElement nestedElement = elementWithHover.createBaseElement(By.xpath("//div[@id='childElement"));
+        assertThat(nestedElement.getCollapsedHoverElement().getBy()).isEqualTo(By.xpath("//div[@id='hoverElement']"));
+        assertThat(nestedElement.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='elementWithHover']//div[@id='childElement"));
+    }
+
+    @Test
+    public void nestElementWithMultipleHover() {
+        BaseElement hoverElement = new BaseElement(By.xpath("//div[@id='hoverElement']"));
+        BaseElement hoverElement2 = new BaseElement(By.xpath("//div[@id='hoverElementTwo']"));
+        BaseElement elementWithHover = new BaseElement(By.xpath("//div[@id='elementWithHover']")).withHover(hoverElement);
+        BaseElement elementWithHover2 = elementWithHover.createBaseElement(By.xpath("//div[@id='elementWithHoverTwo']")).withHover(hoverElement2);
+        BaseElement nestedElement = elementWithHover2.createBaseElement(By.xpath("//div[@id='childElement']"));
+
+        assertThat(elementWithHover2.getCollapsedXpathBy()).isNull();
+        assertThat(nestedElement.getCollapsedHoverElement().getBy()).isEqualTo(By.xpath("//div[@id='hoverElementTwo']"));
+        assertThat(nestedElement.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='elementWithHoverTwo']//div[@id='childElement']"));
+    }
+
+    @Test
+    public void nestedElementsWithDifferentLocators() {
+        BaseElement xpathElement1 = new BaseElement(By.xpath("//div[@id='test1']"));
+        BaseElement xpathElement2 = xpathElement1.createBaseElement(By.xpath("//div[@id='test2']"));
+        BaseElement idLocator1 = xpathElement2.createBaseElement(By.id("testId"));
+        BaseElement xpathElement3 = idLocator1.createBaseElement(By.xpath("//div[@id='test3']"));
+        BaseElement xpathElement4 = xpathElement3.createBaseElement(By.xpath("//div[@id='test4']"));
+        assertThat(xpathElement1.getCollapsedXpathBy()).isNull();
+        assertThat(xpathElement2.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='test1']//div[@id='test2']"));
+        assertThat(idLocator1.getCollapsedXpathBy()).isNull();
+        assertThat(xpathElement3.getCollapsedXpathBy()).isNull();
+        assertThat(xpathElement4.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='test3']//div[@id='test4']"));
+
+    }
+
+    @Ignore
+    @Test
+    public void nestedElementListWithNestedDivs() {
+        BaseElement listContainer = new BaseElement(By.xpath("//div[@id='nested_list_container']"));
+        BaseElement ul = listContainer.createBaseElement(By.xpath("//ul[@id='nested_list']"));
+        ElementList<BaseElement> list = ul.createBaseElements(By.xpath("//li[@class='nested_item']"));
+        assertThat(list).hasSize(3);
+        assertThat(list.get(0).getText()).isEqualTo("Item 1");
+        assertThat(list.get(1).getText()).isEqualTo("Item 2");
+        assertThat(list.get(2).getText()).isEqualTo("Item 3");
+    }
+
+    @Test
+    public void parentHasAutoscroll() {
+        BaseElement parent = new BaseElement(By.xpath("//div[@id='parent']")).withAutoScrollIntoView();
+        BaseElement child = parent.createBaseElement(By.xpath("//div[@id='child']"));
+        assertThat(parent.getCollapsedXpathBy()).isNull();
+        assertThat(child.getCollapsedXpathBy()).isNull();
+    }
+
+    @Test
+    public void childAndParentHaveAutoScroll() {
+        BaseElement parent = new BaseElement(By.xpath("//div[@id='parent']")).withAutoScrollIntoView();
+        BaseElement child = parent.createBaseElement(By.xpath("//div[@id='child']")).withAutoScrollIntoView();
+        assertThat(parent.getCollapsedXpathBy()).isNull();
+        assertThat(child.getCollapsedXpathBy()).isNull();
+    }
+
+    @Test
+    public void childHasAutoScrollandParentDoesNot() {
+        BaseElement parent = new BaseElement(By.xpath("//div[@id='parent']"));
+        BaseElement child = parent.createBaseElement(By.xpath("//div[@id='child']")).withAutoScrollIntoView();
+        assertThat(parent.getCollapsedXpathBy()).isNull();
+        assertThat(child.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='parent']//div[@id='child']"));
+    }
+}

--- a/src/test/java/com/lithium/mineraloil/selenium/elements/NestedXpathTest.java
+++ b/src/test/java/com/lithium/mineraloil/selenium/elements/NestedXpathTest.java
@@ -1,12 +1,12 @@
 package com.lithium.mineraloil.selenium.elements;
 
-import org.junit.Ignore;
+import com.lithium.mineraloil.selenium.helpers.BaseTest;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NestedXpathTest {
+public class NestedXpathTest extends BaseTest {
 
     @Test
     public void nestedElementCollapseXpath() {
@@ -15,15 +15,19 @@ public class NestedXpathTest {
         BaseElement levelThree = levelTwo.createBaseElement(By.xpath("//div[@id='level_3']"));
         BaseElement levelFour = levelThree.createBaseElement(By.xpath("//div[@id='level_4']"));
         assertThat(levelOne.getCollapsedXpathBy()).isNull();
+        assertThat(levelOne.getParentElement()).isNull();
         assertThat(levelTwo.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='level_1']//div[@id='level_2']"));
+        assertThat(levelTwo.getCollapsedParent()).isNull();
         assertThat(levelThree.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='level_1']//div[@id='level_2']//div[@id='level_3']"));
+        assertThat(levelThree.getCollapsedParent()).isNull();
         assertThat(levelFour.getCollapsedXpathBy()).isEqualTo(By.xpath("//div[@id='level_1']//div[@id='level_2']//div[@id='level_3']//div[@id='level_4']"));
-//        assertThat(levelThree.getText()).contains("Level 3", "Welcome to the last level");
-//        assertThat(levelTwo.getText()).contains("Level 2", "Level 3", "Welcome to the last level");
-//        assertThat(levelOne.getText()).contains("Level 1", "Level 2", "Level 3", "Welcome to the last level");
+        assertThat(levelThree.getCollapsedParent()).isNull();
+
+        assertThat(levelThree.getText()).contains("Level 3", "Welcome to the last level");
+        assertThat(levelTwo.getText()).contains("Level 2", "Level 3", "Welcome to the last level");
+        assertThat(levelOne.getText()).contains("Level 1", "Level 2", "Level 3", "Welcome to the last level");
     }
 
-    @Ignore
     @Test
     public void nestedElementList() {
         ElementList<BaseElement> list = new ElementList<>(By.xpath("//li[@class='nested_item']"), BaseElement.class);
@@ -33,7 +37,6 @@ public class NestedXpathTest {
         assertThat(list.get(2).getText()).isEqualTo("Item 3");
     }
 
-    @Ignore
     @Test
     public void nestedElementListWithNestedElement() {
         ElementList<BaseElement> list = new ElementList<>(By.xpath("//li[@class='nested_item']"), BaseElement.class);
@@ -82,7 +85,6 @@ public class NestedXpathTest {
 
     }
 
-    @Ignore
     @Test
     public void nestedElementListWithNestedDivs() {
         BaseElement listContainer = new BaseElement(By.xpath("//div[@id='nested_list_container']"));

--- a/src/test/resources/htmls/iframe.html
+++ b/src/test/resources/htmls/iframe.html
@@ -4,5 +4,11 @@
 </head>
 <body>
     <div id="iframe_div">Iframe Things!</div>
+    <div id="iframe_level_1">
+        Level 1
+        <div id="iframe_level_2">
+            Level 2
+        </div>
+    </div>
 </body>
 </html>

--- a/src/test/resources/htmls/test.html
+++ b/src/test/resources/htmls/test.html
@@ -41,9 +41,25 @@
         Level 2
         <div id="level_3">
             Level 3
-            <div id="level_4">Welcome to the last level</div>
+            <div id="level_4">
+                Welcome to the last level
+            </div>
         </div>
     </div>
+</div>
+
+<div id="nested_list_container">
+    <ul id="nested_list">
+        <li class="nested_item">
+            <div class="nested_text">Item 1</div>
+        </li>
+        <li class="nested_item">
+            <div class="nested_text">Item 2</div>
+        </li>
+        <li class="nested_item">
+            <div class="nested_text">Item 3</div>
+        </li>
+    </ul>
 </div>
 
 </body>

--- a/src/test/resources/htmls/test.html
+++ b/src/test/resources/htmls/test.html
@@ -35,6 +35,16 @@
     <input type="checkbox" name="Yes" value="Yes">Yes
     <input type="checkbox" name="No" value="No">No
 </div>
+<div id="level_1">
+    Level 1
+    <div id="level_2">
+        Level 2
+        <div id="level_3">
+            Level 3
+            <div id="level_4">Welcome to the last level</div>
+        </div>
+    </div>
+</div>
 
 </body>
 


### PR DESCRIPTION
#When a child is added to a parent element, the code will try to collapse the xpaths to make searching in the DOM faster than doing a locate for the parent every single time before finding the child.

Some Conditions for not collapsing when both parent and child have By.Xpath
- If the parent has an iframe, don't collapse
- If the parent has a hoverElement and child has a hoverElement, don't collapse
- If the parent has autoscrollintoview, don't collapse
- If the parent is an element of a list, don't collapse

Other Conditions for collapsing
- If the parent does not have a hoverElement and child has a hoverElement, collapse the xpath
- If the parent has a hoverElement and child does not, collapse the xpath
- If the parent does not have autoscrollintoview and child does, collapse the xpath

The locateElement changes are pretty much 
If collapsed variable is null, use original method of searching.

1/12/2017
Changes
- No longer collapses or un-collapses hoverElements. Use case is probably one hover element and never two hover elements for the child and parent





