### PR TITLE
Updated exception thrown in SelectListElement to be the Selenium error encountered 

### DIFF
--- a/src/main/java/com/lithium/mineraloil/selenium/elements/SelectListElement.java
+++ b/src/main/java/com/lithium/mineraloil/selenium/elements/SelectListElement.java
@@ -43,29 +43,33 @@ public class SelectListElement implements Element<SelectListElement>, SelectList
     public String getSelectedOption() {
         int retries = 0;
         long expireTime = Instant.now().toEpochMilli() + SECONDS.toMillis(Waiter.DISPLAY_WAIT_S);
-        while (Instant.now().toEpochMilli() < expireTime && retries < 2) {
+        while (true) {
             try {
                 return new Select(elementImpl.locateElement()).getFirstSelectedOption().getText();
             } catch (WebDriverException e) {
                 retries++;
+                if(Instant.now().toEpochMilli() >= expireTime || retries > 1) {
+                    throw e;
+                }
             }
         }
-        throw new NoSuchElementException("Unable to locate element: " + getBy());
     }
 
     @Override
     public void select(String optionText) {
         int retries = 0;
         long expireTime = Instant.now().toEpochMilli() + SECONDS.toMillis(Waiter.DISPLAY_WAIT_S);
-        while (Instant.now().toEpochMilli() < expireTime && retries < 2) {
+        while (true) {
             try {
                 new Select(elementImpl.locateElement()).selectByVisibleText(optionText);
                 return;
             } catch (WebDriverException e) {
                 retries++;
+                if(Instant.now().toEpochMilli() >= expireTime || retries > 1) {
+                    throw e;
+                }
             }
         }
-        throw new NoSuchElementException("Unable to locate element: " + getBy());
     }
 
     @Override
@@ -88,7 +92,7 @@ public class SelectListElement implements Element<SelectListElement>, SelectList
     public List<String> getAvailableOptions() {
         int retries = 0;
         long expireTime = Instant.now().toEpochMilli() + SECONDS.toMillis(Waiter.DISPLAY_WAIT_S);
-        while (Instant.now().toEpochMilli() < expireTime && retries < 2) {
+        while (true) {
             try {
                 return new Select(elementImpl.locateElement()).getOptions()
                                                               .stream()
@@ -96,8 +100,11 @@ public class SelectListElement implements Element<SelectListElement>, SelectList
                                                               .collect(Collectors.toList());
             } catch (WebDriverException e) {
                 retries++;
+                if(Instant.now().toEpochMilli() >= expireTime || retries > 1) {
+                    throw e;
+                }
             }
         }
-        throw new NoSuchElementException("Unable to locate element: " + getBy());
     }
 }
+


### PR DESCRIPTION
Hello MineralOil maintainers!
<br/>
I ran into a bug in SelectListElement where the exception thrown was incorrect.  We had a test failure where the option the test was trying to select was not available.  However the error thrown was:
`org.openqa.selenium.NoSuchElementException: Unable to locate element: By.id: someSelectListId
...`
Which didn't make sense since the select element was found.  Instead, the option in that select element did not exist.
<br/>


Looking at the code, it looks like a general `NoSuchElementException` was being thrown regardless of the error encountered in the retry logic.  I thought it might be helpful for debugging if the function threw the error selenium encountered if we exceeded the time or retry limit.  In this way we can fail with:
* Select element not found looks like:
    * `org.openqa.selenium.NoSuchElementException: no such element: Unable to locate element: {"method":"id","selector":"someSelectListId"} ...`
* Select element option not found looks like:
    * `org.openqa.selenium.NoSuchElementException: Cannot locate element with text: someListOptionText ...`
<br/>

To do this I made the while loop into a `while true` (yes not the most elegant solution, but this avoids having to save the exception and then throw it at the end) and moved the loop condition into the catch, so if we had exceeded the time or retry limit we just throw the exception we hit.
<br/>

Let me know if this code looks good or if you would like any changes.  Thanks!
